### PR TITLE
Add PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "issues": "https://github.com/neilime/php-css-lint/issues"
   },
   "require": {
-    "php": "^7.3",
+    "php": "^7.3 || ^8",
     "ext-json": "*"
   },
   "require-dev": {

--- a/tests/TestSuite/LinterTest.php
+++ b/tests/TestSuite/LinterTest.php
@@ -10,9 +10,20 @@ class LinterTest extends \PHPUnit\Framework\TestCase
      */
     protected $linter;
 
+    /**
+     * @var string
+     */
+    protected $phpVersion;
+
     protected function setUp(): void
     {
         $this->linter = new \CssLint\Linter();
+        $php_version = phpversion();
+        if (version_compare($php_version, '8.0.0', '>=')) {
+            $this->phpVersion = '8';
+        } else {
+            $this->phpVersion = '7';
+        }
     }
 
     public function testConstructWithCustomCssLintProperties()
@@ -113,20 +124,30 @@ class LinterTest extends \PHPUnit\Framework\TestCase
     public function testLintStringWithWrongTypeParam()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(
-            'Argument 1 passed to CssLint\Linter::lintString() must be of the type string, array given'
-        );
-
+        if ($this->phpVersion == '8') {
+            $this->expectExceptionMessage(
+                'CssLint\Linter::lintString(): Argument #1 ($sString) must be of type string, array given'
+            );
+        } else {
+            $this->expectExceptionMessage(
+                'Argument 1 passed to CssLint\Linter::lintString() must be of the type string, array given'
+            );
+        }
         $this->linter->lintString(['wrong']);
-        $this->assertFalse(false);
     }
 
     public function testLintFileWithWrongTypeParam()
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(
-            'Argument 1 passed to CssLint\Linter::lintFile() must be of the type string, array given'
-        );
+        if ($this->phpVersion == '8') {
+            $this->expectExceptionMessage(
+                'CssLint\Linter::lintFile(): Argument #1 ($sFilePath) must be of type string, array given'
+            );
+        } else {
+            $this->expectExceptionMessage(
+                'Argument 1 passed to CssLint\Linter::lintFile() must be of the type string, array given'
+            );
+        }
         $this->linter->lintFile(['wrong']);
     }
 


### PR DESCRIPTION
This PR seeks to add PHP 8 support to composer.json and to update tests for compatibility.

A code scan doesn't reveal any compatibility issues:

```
$ vendor/squizlabs/php_codesniffer/bin/phpcs --standard=PHPCompatibility src/ --runtime-set testVersion 8.0
$
```

```
$ vendor/squizlabs/php_codesniffer/bin/phpcs --standard=PHPCompatibility tests/ --runtime-set testVersion 8.0
$
```

```
$ vendor/squizlabs/php_codesniffer/bin/phpcs --standard=PHPCompatibility scripts/ --runtime-set testVersion 8.0
$
```

Tests pass successfully post-update on both PHP 7.3 and PHP 8.0.

Tests with PHP 7.3:

```
$ composer test
> phpunit --colors --configuration tests/phpunit.xml
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.16
Configuration: tests/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............                                                   15 / 15 (100%)

Time: 00:00.251, Memory: 6.00 MB

OK (15 tests, 25 assertions)
```

Tests with PHP 8.0:

```
$ composer test
> phpunit --colors --configuration tests/phpunit.xml
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.0
Configuration: tests/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............                                                   15 / 15 (100%)

Time: 00:01.768, Memory: 4.00 MB

OK (15 tests, 25 assertions)

```

Note: PHP compatibility will need to be addressed in dependencies before php-css-lint can be installed on PHP 8; however. To run tests in PHP 8, I installed with PHP 7.3 and then swapped out versions in DDEV.