### PR TITLE
Support CSS variables

### DIFF
--- a/src/CssLint/Linter.php
+++ b/src/CssLint/Linter.php
@@ -386,9 +386,15 @@ class Linter
         }
 
         if ($sChar === ':') {
-            // Check if property name exists
             $sPropertyName = trim($this->getContextContent());
 
+            // Ignore CSS variables (names starting with --)
+            if (substr($sPropertyName, 0, 2) === '--') {
+                $this->setContext(self::CONTEXT_PROPERTY_CONTENT);
+                return true;
+            }
+            
+            // Check if property name exists
             if (!$this->getCssLintProperties()->propertyExists($sPropertyName)) {
                 $this->addError('Unknown CSS property "' . $sPropertyName . '"');
             }

--- a/tests/_files/valid.css
+++ b/tests/_files/valid.css
@@ -1,4 +1,8 @@
-.button.drodown::after {
+:root {
+  --border-radius: 3px;
+}
+
+.button.dropdown::after {
   display: block;
   width: 0;
   height: 0;
@@ -7,6 +11,7 @@
   border-bottom-width: 0;
   border-top-style: solid;
   border-color: #fefefe transparent transparent;
+  border-radius: var(--border-radius);
   position: relative;
   top: 0.4em;
   display: inline-block;


### PR DESCRIPTION
This intercepts the property name and validates it if it starts with 2 dashes (--can-be-anything). Checking only the first character didn't work, because that interferes with validation of vendor prefixes.

I was unable to get the tests running locally, sorry.. But I added a CSS variable to the valid.css test file, and that validates with this fix applied. So this fixes #80 for me also.

Thank you for providing this useful tool!