### PR TITLE
Allow numeric characters in property names

### DIFF
--- a/src/CssLint/Linter.php
+++ b/src/CssLint/Linter.php
@@ -402,7 +402,7 @@ class Linter
             return true;
         }
 
-        if (!preg_match('/[-a-zA-Z]+/', $sChar)) {
+        if (!preg_match('/[-a-zA-Z0-9]+/', $sChar)) {
             $this->addError('Unexpected property name token "' . $sChar . '"');
         }
         return true;


### PR DESCRIPTION
With the (possible) addition of validating CSS variables, property names could also contain numeric characters.

Something like `--vertical-rhythm-3` is perfectly valid, but this is currently blocked by the final regex check.